### PR TITLE
Added xs_edistance_bytes: compare byte strings.

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -70,3 +70,20 @@ CODE:
   }
 OUTPUT:
   RETVAL
+
+int
+cxs_edistance_bytes (src, tgt, maxDistance)
+  unsigned char *src
+  unsigned char *tgt
+  unsigned int maxDistance
+CODE:
+  unsigned int lenSource = strlen(src);
+  unsigned int lenTarget = strlen(tgt);
+  if (lenSource > 0 && lenTarget > 0)
+    RETVAL = distance_bytes(src, tgt, lenSource, lenTarget, maxDistance);
+  else if (lenSource > lenTarget)
+    RETVAL = lenSource;
+  else
+    RETVAL = lenTarget;
+OUTPUT:
+  RETVAL

--- a/damerau-int.c
+++ b/damerau-int.c
@@ -123,3 +123,65 @@ static int distance(unsigned int src[],unsigned int tgt[],unsigned int x,unsigne
   return (maxDistance != 0 && maxDistance < score)?(-1):score;
   }
 }
+
+/* This is a variation of distance() that works on byte strings.  This is
+ * faster when working on strings that are known not to contain multi-byte
+ * characters thanks to a simpler way the dictionary is implemented.
+ */
+static int
+distance_bytes (const unsigned char *src, const unsigned char *tgt,
+                unsigned int x, unsigned int y, unsigned int maxDistance)
+{
+  unsigned int dict[0x100];
+  unsigned int swapCount,swapScore,targetCharCount,i,j;
+  unsigned int *scores = malloc( (x + 2) * (y + 2) * sizeof(unsigned int));
+  unsigned int score_ceil = x + y;
+  memset(dict, 0, sizeof(dict));
+ 
+  /* intialize matrix start values */
+  scores[0] = score_ceil;  
+  scores[1 * (y + 2) + 0] = score_ceil;
+  scores[0 * (y + 2) + 1] = score_ceil;
+  scores[1 * (y + 2) + 1] = 0;
+
+  /* work loops    */
+  /* i = src index */
+  /* j = tgt index */
+  for(i=1;i<=x;i++){ 
+    scores[(i+1) * (y + 2) + 1] = i;
+    scores[(i+1) * (y + 2) + 0] = score_ceil;
+    swapCount = 0;
+
+    for(j=1;j<=y;j++){
+      if(i == 1) {
+          scores[1 * (y + 2) + (j + 1)] = j;
+          scores[0 * (y + 2) + (j + 1)] = score_ceil;
+      }
+
+      targetCharCount = dict[ tgt[j-1] ];
+      swapScore = scores[targetCharCount * (y + 2) + swapCount] + i - targetCharCount - 1 + j - swapCount;
+
+      if(src[i-1] != tgt[j-1]){      
+        scores[(i+1) * (y + 2) + (j + 1)] = MIN(swapScore,(MIN(scores[i * (y + 2) + j], MIN(scores[(i+1) * (y + 2) + j], scores[i * (y + 2) + (j + 1)])) + 1));
+      }else{ 
+        swapCount = j;
+        scores[(i+1) * (y + 2) + (j + 1)] = MIN(scores[i * (y + 2) + j], swapScore);
+      }
+    }
+
+
+    //if(maxDistance != 0 && maxDistance < scores[(i+1) * (y + 2) + (y + 1)]) {
+    //  dict_free(head);
+    //  free(scores);
+    //  return -1;
+    //}
+
+    dict[ src[i-1] ] = i;
+  }
+
+  {
+  unsigned int score = scores[(x+1) * (y + 2) + (y + 1)];
+  free(scores);
+  return (maxDistance != 0 && maxDistance < score)?(-1):score;
+  }
+}

--- a/lib/Text/Levenshtein/Damerau/XS.pm
+++ b/lib/Text/Levenshtein/Damerau/XS.pm
@@ -5,7 +5,7 @@ use 5.008_008;
 require Exporter;
  
 $Text::Levenshtein::Damerau::XS::VERSION = '3.0';
-@Text::Levenshtein::Damerau::XS::EXPORT_OK = qw/xs_edistance/;
+@Text::Levenshtein::Damerau::XS::EXPORT_OK = qw/xs_edistance xs_edistance_bytes/;
 @Text::Levenshtein::Damerau::XS::ISA = qw/Exporter/;
 
 eval {
@@ -24,6 +24,10 @@ eval {
 sub xs_edistance {
     # shift shift shift is faster than $_[0] $_[1] $_[2] 
     return Text::Levenshtein::Damerau::XS::cxs_edistance( [unpack('U*', shift)], [unpack('U*',shift)], shift || 0);
+}
+
+sub xs_edistance_bytes {
+    return Text::Levenshtein::Damerau::XS::cxs_edistance_bytes(shift, shift, shift || 0);
 }
 
 1;
@@ -85,6 +89,11 @@ Wrapper function to take the edit distance between a source and target string us
 	print xs_edistance('Neil','Niely',1); # distance is 2
 	# prints -1
 
+=head2 xs_edistance_bytes
+
+Same as C<xs_edistance()>, except it works on the strings byte by
+byte.  If you have ASCII strings, for example, this version is faster.
+
 =head1 TODO
 
 =over 4
@@ -92,8 +101,6 @@ Wrapper function to take the edit distance between a source and target string us
 =item * Handle very large strings of text. Can be accomplished by reworking the scoring matrix or writing to disk.
 
 =item * Add from_file methods.
-
-=item * Add binary/byte string support.
 
 =back
 

--- a/t/02_xs_edistance.t
+++ b/t/02_xs_edistance.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
-use Test::More tests => 24;
-use Text::Levenshtein::Damerau::XS qw/xs_edistance/;
+use Test::More tests => 42;
+use Text::Levenshtein::Damerau::XS qw/xs_edistance xs_edistance_bytes/;
 
 is( xs_edistance('four','for'), 	1, 'test xs_edistance insertion');
 is( xs_edistance('four','four'), 	0, 'test xs_edistance matching');
@@ -23,6 +23,27 @@ is( xs_edistance("xxx","xxxx",3),   1,  'test xs_edistance misc 3');
 is( xs_edistance("xxxx","xxx",1),   1,  'test xs_edistance misc 4');
 is( xs_edistance("xxxx","xxx",2),   1,  'test xs_edistance misc 5');
 is( xs_edistance("xxxx","xxx",3),   1,  'test xs_edistance misc 6');
+
+is( xs_edistance_bytes('four','for'), 	1, 'test xs_edistance_bytes insertion');
+is( xs_edistance_bytes('four','four'), 	0, 'test xs_edistance_bytes matching');
+is( xs_edistance_bytes('four','fourth'), 	2, 'test xs_edistance_bytes deletion');
+is( xs_edistance_bytes('four','fuor'), 	1, 'test xs_edistance_bytes transposition');
+is( xs_edistance_bytes('four','fxxr'), 	2, 'test xs_edistance_bytes substitution');
+is( xs_edistance_bytes('four','FOuR'), 	3, 'test xs_edistance_bytes case');
+is( xs_edistance_bytes('four',''), 		4, 'test xs_edistance_bytes target empty');
+is( xs_edistance_bytes('','four'), 		4, 'test xs_edistance_bytes source empty');
+is( xs_edistance_bytes('',''), 			0, 'test xs_edistance_bytes source and target empty');
+is( xs_edistance_bytes('111','11'), 		1, 'test xs_edistance_bytes numbers');
+is( xs_edistance_bytes('xxx','x',1),     -1, 'test xs_edistance_bytes > max distance setting');
+is( xs_edistance_bytes('xxx','xx',1),    	1, 'test xs_edistance_bytes <= max distance setting');
+
+# some extra maxDistance tests
+is( xs_edistance_bytes("xxx","xxxx",1),   1,  'test xs_edistance_bytes misc 1');
+is( xs_edistance_bytes("xxx","xxxx",2),   1,  'test xs_edistance_bytes misc 2');
+is( xs_edistance_bytes("xxx","xxxx",3),   1,  'test xs_edistance_bytes misc 3');
+is( xs_edistance_bytes("xxxx","xxx",1),   1,  'test xs_edistance_bytes misc 4');
+is( xs_edistance_bytes("xxxx","xxx",2),   1,  'test xs_edistance_bytes misc 5');
+is( xs_edistance_bytes("xxxx","xxx",3),   1,  'test xs_edistance_bytes misc 6');
 
 
 # Test some utf8


### PR DESCRIPTION
This version of the function compares two strings byte by byte.  distance()
has been copied and modified to work with byte arrays and to use a simpler
dictionary.  Because the dictionary is simple, this function is faster than
the original.

My motivation for this change was to speed up the comparison.  When comparing
ASCII strings, it is faster not to convert a byte array into an integer array and to use
a malloc-less dictionary.  In my testing, the proposed function is five to six times faster
for ASCII strings:

```
use Benchmark;

use Text::Levenshtein::Damerau::PP qw/pp_edistance/;
use Text::Levenshtein::Damerau::XS qw/xs_edistance xs_edistance_bytes/;

timethese(1000000, {
   'PP Dist' =>       sub { pp_edistance('four', 'fuor') },
   'XS Dist' =>       sub { xs_edistance('four', 'fuor') },
   'XS Dist Bytes' => sub { xs_edistance_bytes('four', 'fuor') },
})
```

Produces

```
Benchmark: timing 1000000 iterations of PP Dist, XS Dist, XS Dist Bytes...
   PP Dist: 204 wallclock secs (202.16 usr +  1.64 sys = 203.80 CPU) @ 4906.77/s (n=1000000)
   XS Dist: 13 wallclock secs (12.56 usr +  0.07 sys = 12.63 CPU) @ 79176.56/s (n=1000000)
XS Dist Bytes:  2 wallclock secs ( 2.68 usr +  0.01 sys =  2.69 CPU) @ 371747.21/s (n=1000000)
```
